### PR TITLE
Update packages requirements per toil 9.2.0 (bonus: enables aarch64)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,12 +27,12 @@ requirements:
   host:
     - python {{ python_min }}
     - pip
-    - setuptools >=42
+    - setuptools >=65.5.1,<83
     - wheel
   run:
     - python >={{ python_min }}
     - dill >=0.3.2,<0.4
-    - requests >2,<=2.31.0
+    - requests >2,<=2.32.5
     - docker-py >=6.1.0,<8
     - urllib3 >=1.26.0,<3
     - python-dateutil
@@ -66,14 +66,14 @@ requirements:
     #encryption reqs
     - pynacl >=1.4.0,<2
     #google reqs
-    - apache-libcloud >=2.2.1,<3
+    - apache-libcloud >=3.6.1,<4
     - google-cloud-storage >=2,<=2.8.0
     - google-auth >=2.18.1,<3
     #cwl reqs
-    - cwltool ==3.1.20250110105449
+    - cwltool ==3.1.20260108082145
     - schema-salad >=8.4.20230128170514,<9
     - galaxy-tool-util <26
-    - ruamel.yaml >=0.15,<=0.19
+    - ruamel.yaml >=0.15,<=0.19.1
     - ruamel.yaml.clib >=0.2.6
     - networkx <4
     - cachecontrol-with-filecache
@@ -81,10 +81,10 @@ requirements:
     #htcondor reqs
     - python-htcondor >=23.6.0,<25
     #kubernetes reqs
-    - python-kubernetes >=12.0.1,<33
+    - python-kubernetes >=12.0.1,<36
     - idna >=2
     #wdl reqs
-    - miniwdl ==1.13.0
+    - miniwdl ==1.13.1
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: a53f2d4f6008cf44ef432571d3073aa23b7eb6c3795db3c168f7882f4622cfa9
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --no-cache-dir -vvv
   entry_points:


### PR DESCRIPTION

The toil 9.2,0 release bumps various dependency requirement versions, this PR brings those in.

A nice bonus is that requirements-wdl.txt bumps the miniwdl accepted version up to a version of miniwdl (1.13.1) - and  that is the first miniwdl that exists on linux-aarch64 - which should mean we can now run toil on linux-aarch64  





<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
